### PR TITLE
fix: correct data object access in payment success handling

### DIFF
--- a/src/app/success-payment/success-payment.component.ts
+++ b/src/app/success-payment/success-payment.component.ts
@@ -30,11 +30,11 @@ export class SuccessPaymentComponent implements OnInit {
         this.paymentService.getPaymentSuccess(sessionId).subscribe({
           next: (data) => {
             debugger
-            this.userName = data.name;
-            this.planName = data.plan;
-            this.cost = data.cost + ' ' + data.currency;
-            this.purchaseDate = data.paymentDate;
-            this.nextRenewal = data.nextPaymentDate;
+            this.userName = data.object.name;
+            this.planName = data.object.plan;
+            this.cost = data.object.cost + ' ' + data.object.currency;
+            this.purchaseDate = data.object.paymentDate;
+            this.nextRenewal = data.object.nextPaymentDate;
             this.loading = false;
           },
           error: (err) => {


### PR DESCRIPTION
This pull request updates how payment success data is accessed in the `SuccessPaymentComponent`. Instead of reading properties directly from the response, the component now reads them from the nested `object` property of the response data.

Data access refactor:

* Updated the assignment of `userName`, `planName`, `cost`, `purchaseDate`, and `nextRenewal` to retrieve values from `data.object` instead of directly from `data` in the `SuccessPaymentComponent` (`src/app/success-payment/success-payment.component.ts`).