### PR TITLE
fix: Remove asterisks from the 'since' date display in NavBar

### DIFF
--- a/src/app/landing-page-tenant/nav-bar/nav-bar.component.html
+++ b/src/app/landing-page-tenant/nav-bar/nav-bar.component.html
@@ -27,7 +27,7 @@
     <div class="overlay-bottom ">
       <h2 class="text-primary font-weight-medium m-0" style="color: #DA9F5B !important;">Estamos para servirte</h2>
       <h1 class="display-1 text-white m-0">{{ bussinessName }}</h1>
-  <h2 class="text-white m-0">* {{ since }} *</h2>
+  <h2 class="text-white m-0">{{ since }}</h2>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This pull request makes a minor update to the display of the `since` value in the navigation bar component. The change removes the asterisks surrounding the `since` value, resulting in a cleaner and more consistent appearance.

* Removed asterisks from the `since` value in the `nav-bar.component.html`, so it now displays as plain text.